### PR TITLE
HTMLがinvalidになっていた問題を修正

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,9 +15,11 @@ export default function RootLayout({
   children: React.ReactNode
 }) {
   return (
-    <>
-      <Header />
-      <body className={inter.className}>{children}</body>
-    </>
+    <html>
+      <body className={inter.className}>
+        <Header />
+        {children}
+      </body>
+    </html>
   )
 }


### PR DESCRIPTION
layout.tsxのルートはhtml要素になっていないといけなかったっぽいので修正しました。
ついでに`<Header />`を`body`の中に移動させました (紛らわしい)

ランキングが出ないのはこれが原因だったっぽいですね（エラーになってほしい）

参考:
https://zenn.dev/temasaguru/articles/546f0fcdd9d131