### PR TITLE
fix UserDataProvider

### DIFF
--- a/src/components/functional/UserDataGuard.tsx
+++ b/src/components/functional/UserDataGuard.tsx
@@ -1,3 +1,4 @@
+import { logout } from '@/firebase/auth'
 import { useUserDataContext } from '@/providers/UserDataProvider'
 import { redirect } from 'next/navigation'
 import { ReactNode } from 'react'
@@ -11,7 +12,14 @@ export const UserDataGuard: React.FC<UserDataGuardProps> = ({
 }: UserDataGuardProps) => {
   const { userData } = useUserDataContext()
 
-  if (!userData || userData?.groupName === undefined) return redirect('/signin')
+  if (userData === undefined) {
+    return <div>Now Loading...</div>
+  }
+
+  if (userData === null || userData?.groupName === undefined) {
+    logout()
+    return redirect('/signin')
+  }
 
   return <>{children}</>
 }

--- a/src/providers/UserDataProvider.tsx
+++ b/src/providers/UserDataProvider.tsx
@@ -8,7 +8,7 @@ interface UserContextProps {
 }
 
 interface UserContextValues {
-  userData?: UserData
+  userData?: UserData | null
   setUserData?: (data: UserData) => void //応急処置
 }
 
@@ -18,18 +18,21 @@ const UserDataContext = createContext<UserContextValues>({
 
 // デモ用のゴミ実装なので早急に何とかする
 export const UserDataProvider: React.FC<UserContextProps> = ({ children }) => {
-  const [userData, setUserData] = useState<UserData | undefined>(undefined)
+  const [userData, setUserData] = useState<UserData | undefined | null>(
+    undefined
+  )
 
   useEffect(() => {
     const callback = () => {
       const userName = localStorage.getItem('userName') ?? undefined
       const groupName = localStorage.getItem('groupName') ?? undefined
-      setUserData(userName ? { userName, groupName } : undefined)
+      setUserData(userName ? { userName, groupName } : null)
     }
     window.addEventListener('storage', callback)
+    callback()
 
     return () => window.removeEventListener('storage', callback)
-  }, [userData])
+  }, [])
 
   return (
     <UserDataContext.Provider


### PR DESCRIPTION
稀にユーザー名の表示がなくなる問題について※
UserDataProviderのリロード時の挙動が足りていなかったので修正しました。

メモ:
リロード時にUserDataの中身が空になる→groupNameがない判定→UserDataGuardでsigninへ→ログインは成功しているのでregisterへ飛ばされる → groupNameが設定されるがuserNameは空 → 名前が空になる (？) だと思われる