### PR TITLE
fix BACKEND_API_ENDPOINT env name

### DIFF
--- a/src/api/backend/register.ts
+++ b/src/api/backend/register.ts
@@ -1,7 +1,7 @@
 import { Configuration, UsersApi } from '../generated/'
 
 const conf = new Configuration({
-  basePath: process.env.BACKEND_API_ENDPOINT,
+  basePath: process.env.NEXT_PUBLIC_BACKEND_API_ENDPOINT,
   headers: {
     'Content-Type': 'application/json',
   },

--- a/src/hooks/useFetchRanking.ts
+++ b/src/hooks/useFetchRanking.ts
@@ -7,7 +7,7 @@ import {
 } from '../api/generated'
 
 const conf = new Configuration({
-  basePath: process.env.BACKEND_API_ENDPOINT,
+  basePath: process.env.NEXT_PUBLIC_BACKEND_API_ENDPOINT,
   headers: {
     'Content-Type': 'application/json',
   },


### PR DESCRIPTION
クライアントサイドで `BACKEND_API_ENDPOINT` が `undefined` になる問題を修正

メモ:
環境変数には `NEXT_PUBLIC_` 接頭辞をつけないとクライアントサイドに公開されないらしい (`undefined`になる)
undefined になってたのでエンドポイントが `/` になってしまっていたっぽい (ローカル環境でregisterが通ったのは同名のページがあってPOSTが成功していたため)