### PR TITLE
GitHubのrepo権限を削除

### DIFF
--- a/src/firebase/auth.ts
+++ b/src/firebase/auth.ts
@@ -15,7 +15,6 @@ import firebaseApp from '@/firebase/firebaseApp'
 import { AuthData } from '@/models/AuthData'
 
 const provider = new GithubAuthProvider()
-provider.addScope('repo')
 
 let authData: AuthData | undefined | null = {
   idToken: undefined,


### PR DESCRIPTION
余計な権限の要求はユーザを不安にさせるのでGitHubのrepo権限を削除しました