### PR TITLE
不完全なダークモード対応を削除

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -17,7 +17,7 @@
 }
 
 body {
-  color: rgb(var(--foreground-rgb));
+  //color: rgb(var(--foreground-rgb));
   background: linear-gradient(
       to bottom,
       transparent,


### PR DESCRIPTION
ダークモード環境でテキストが白くなってしまう挙動について、bodyのフォントcolorの設定を無効にすることで対応しました。