### PR TITLE
WIP ビューポートの設定

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -17,7 +17,10 @@ export default function RootLayout({
   children: React.ReactNode
 }) {
   return (
-    <html>
+    <html lang="ja">
+      <head>
+        <meta name="viewport" content="width=1080" />
+      </head>
       <body className={inter.className}>
         <AuthProvider>
           <UserDataProvider>


### PR DESCRIPTION
端末によって画面サイズが違うのでスマホだと画面が崩れます。
`viewport="width=1080` にするとサイズ固定できるので少なくとも崩れるのが抑制できるのは分かったんですが、リロードしないと適用されない現象が発生しています。