### PR TITLE
ランキングをポーリングしてきてレベルアップのエフェクトを出す処理を追加

### DIFF
--- a/src/components/functional/TimeoutView.tsx
+++ b/src/components/functional/TimeoutView.tsx
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react'
+
+export interface TimeoutViewProps {
+  children: React.ReactNode
+  timeout: number
+}
+
+export const TimeoutView = ({ timeout, children }: TimeoutViewProps) => {
+  const [isTimedOut, setIsTimedout] = useState<boolean>(false)
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setIsTimedout(true)
+    }, timeout)
+
+    return () => clearTimeout(timer)
+  }, [timeout])
+
+  if (!isTimedOut) {
+    return <>{children}</>
+  } else {
+    return <></>
+  }
+}

--- a/src/components/page/MyPage/index.tsx
+++ b/src/components/page/MyPage/index.tsx
@@ -1,10 +1,22 @@
 import { Suspense } from 'react'
+import Image from 'next/image'
 import { useUserDataContext } from '@/providers/UserDataProvider'
 import { Character } from '@/components/model/character/Character/Character'
+import { usePollingRanking } from '@/hooks/usePollingRanking'
+import { TimeoutView } from '@/components/functional/TimeoutView'
 
 export const MyPage: React.FC = () => {
   const { userData } = useUserDataContext()
   const userName = userData?.userName
+
+  const { ranking } = usePollingRanking({
+    interval: 30 * 1000,
+    userName: userName!,
+    initRanking: { ranking: [] },
+  })
+
+  const status = ranking.ranking?.find((user) => user.userName === userName)
+  const isLevelUpped = status?.lv! > 0 && status?.exp === 0
 
   return (
     <div>
@@ -13,6 +25,19 @@ export const MyPage: React.FC = () => {
     rounded-md border border-gray-200/30 shadow-lg"
       >
         {userData?.userName}
+      </div>
+      <div className="flex justify-center">
+        {isLevelUpped && (
+          <TimeoutView timeout={2000}>
+            <Image
+              className="absolute"
+              src={`/LevelUp.gif`}
+              width={280}
+              height={280}
+              alt=""
+            />
+          </TimeoutView>
+        )}
       </div>
       <Suspense fallback={<div className="text-center">Now Loading...</div>}>
         <Character userName={userName!} />

--- a/src/hooks/usePollingRanking.ts
+++ b/src/hooks/usePollingRanking.ts
@@ -1,0 +1,58 @@
+import { useEffect, useState } from 'react'
+import { RankingUserNameGet201Response } from '@/api/generated'
+import { fetchRanking } from './useFetchRanking'
+
+export interface UsePollingRankingProps {
+  interval?: number
+  userName: string
+  initRanking: RankingUserNameGet201Response
+  onRankingUpdated?: (ranking: RankingUserNameGet201Response) => void
+  onUserStatusUpdated?: (ranking: RankingUserNameGet201Response) => void
+}
+
+export const usePollingRanking = ({
+  interval = 60 * 1000,
+  userName,
+  initRanking,
+  onRankingUpdated = () => undefined,
+  onUserStatusUpdated = () => undefined,
+}: UsePollingRankingProps) => {
+  const [ranking, setRanking] =
+    useState<RankingUserNameGet201Response>(initRanking)
+  const [isRankingUpdated, setIsRankingUpdated] = useState(false)
+  const [isUserStatusUpdated, setIsUserStatusUpdated] = useState(false)
+
+  useEffect(() => {
+    const timer = setInterval(async () => {
+      const nextRanking = await fetchRanking({ userName })
+
+      if (JSON.stringify(ranking) !== JSON.stringify(nextRanking)) {
+        if (
+          JSON.stringify(
+            ranking.ranking?.find((u) => u.userName !== userName)
+          ) ===
+          JSON.stringify(
+            nextRanking.ranking?.find((u) => u.userName !== userName)
+          )
+        ) {
+          onUserStatusUpdated(nextRanking)
+          setIsUserStatusUpdated(true)
+        } else {
+          setIsUserStatusUpdated(false)
+        }
+        onRankingUpdated(nextRanking)
+        setRanking(nextRanking)
+        setIsRankingUpdated(true)
+      } else {
+        setIsUserStatusUpdated(false)
+      }
+    }, interval)
+
+    return () => clearInterval(timer)
+  }, [interval, ranking, userName, onRankingUpdated, onUserStatusUpdated])
+
+  //   if (isRankingUpdated) setIsRankingUpdated(false)
+  //   if (isUserStatusUpdated) setIsUserStatusUpdated(false)
+
+  return { ranking, isRankingUpdated, isUserStatusUpdated }
+}


### PR DESCRIPTION
30秒ごとにランキングを見に行って一定の条件を満たしたらレベルアップのエフェクトを2秒間表示する処理を追加しました。
※一定の条件: `lv > 0 && exp === 0`